### PR TITLE
Remove nightly-only line from src/lib.rs to allow stable builds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(duration_millis_float)]
 mod danmaku;
 mod renderer;
 


### PR DESCRIPTION
The build was failing with the default (stable) Rust toolchain
because a nightly-only feature was present in src/lib.rs. Removing
this line allows the project to compile with stable Rust without
requiring nightly.